### PR TITLE
7.0.x-qa-27334

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -868,7 +868,7 @@
 
 		<execute function="SelectFrame" locator1="IFrame#SELECT_SITE_ROLE" />
 
-		<var name="key_roleTitle" value="${siteRoleName}" />
+		<var name="key_roleName" value="${siteRoleName}" />
 		<var name="key_siteRoleName" value="${siteRoleName}" />
 
 		<execute function="AssertTextEquals" locator1="UsersAndOrganizationsEditUser#ROLES_SITE_ROLES_TABLE_TITLE" value1="${siteRoleName}" />

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsEditUser.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsEditUser.path
@@ -177,7 +177,7 @@
 </tr>
 <tr>
 	<td>ROLES_ORGANIZATION_SELECT_CHOOSE_BUTTON</td>
-	<td>//tr[contains(.,'${key_roleTitle}')]/td[2]//button[contains(.,'Choose')]</td>
+	<td>//tr[contains(.,'${key_roleName}')]/td[2]//button[contains(.,'Choose')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-27334

**This is 7.0.x only**

Note that [no tests](https://testray.liferay.com/home/-/testray/case_results?filterStatuses=4%2C3%2C1%2C5%2C7%2C0&testrayRunId=56768409) are failing from the `${key_roleTitle}` error on master branch, so when LPS-66240 is backported, it will be a clean transition from `roleName` to `roleTitle`.  Thanks!