### PR TITLE
master-qa-30012

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/clustering/clusteringframework/ClusteringCE.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/clustering/clusteringframework/ClusteringCE.testcase
@@ -34,26 +34,5 @@
 
 		<execute function="AssertConsoleTextNotPresent" value1="cluster=liferay-channel-control" />
 		<execute function="AssertConsoleTextNotPresent" value1="com.liferay.portal.cluster.multiple" />
-
-		<execute macro="Page#assertNodePortPG">
-			<var name="nodePort" value="8080" />
-		</execute>
-
-		<execute macro="Smoke#viewWelcomePage" />
-
-		<execute macro="Smoke#runSmoke" />
-
-		<execute macro="User#logoutPG">
-			<var name="password" value="test" />
-			<var name="userEmailAddress" value="test@liferay.com" />
-		</execute>
-
-		<execute macro="SignIn#viewSignInError">
-			<var name="error" value="internalServerError" />
-			<var name="nodePort" value="9080" />
-			<var name="password" value="test" />
-			<var name="urlErrorMessage" value="com_liferay_login_web_portlet_LoginPortlet" />
-			<var name="userEmailAddress" value="test@liferay.com" />
-		</execute>
 	</command>
 </definition>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-30012

Please backport this to 7.0.x.

Getting rid of these steps as there's no point in testing functionality for two separated portal instances that share a database. This test should just assert that there are not clustering messages on startup.